### PR TITLE
Add stratigraphic log for Kronos-1 from WCR

### DIFF
--- a/Data/data-notebooks/Kronos formation strat log.ipynb
+++ b/Data/data-notebooks/Kronos formation strat log.ipynb
@@ -1,0 +1,105 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Copy pasted from the second page of the PDF \"WCR_Interp_Rev0.pdf\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fmlog = \"\"\"FORMATION TOPS:\n",
+    "Formation Name MDRT TVDSS Thickness\n",
+    "(m) (m) (mMDRT)\n",
+    "Sea Bed 533.8 -512.0 -\n",
+    "Barracouta Formation 533.8 -512.0 434.0\n",
+    "Oliver Limestone Formation 968.0 -946.0 1475.0\n",
+    "Prion Limestone Formation 2443.0 -2421.0 415.0\n",
+    "Grebe Limestone Formation 2858.0 -2835.4 817.0\n",
+    "Heywood Limestone Member 2858.0 -2835.4 602.0\n",
+    "Baudin Marl Member 3460.0 -3437.2 215.0\n",
+    "Johnson Formation 3675.0 -3652.3 244.0\n",
+    "Woolaston Gibson Fenalon Prudhoe Fm 3919.0 -3897.0 145.0\n",
+    "Jamieson Formation 4064.0 -4042.0 513.0\n",
+    "Montara Formation 4577.0 -4555.2 8.0\n",
+    "Plover Formation (Top Volcanics) 4585.0 -4562.0 191.0\n",
+    "Plover Formation (Top Reservoir) 4776.0 -4753.3 299.0\n",
+    "Nome Formation 5075.0 -5050.9 275.8\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def line_to_items(line):\n",
+    "    line = line.strip()\n",
+    "    mdrt, tvdss, thk = line.rsplit()[-3:]\n",
+    "    fm_name = line.split(mdrt)[0]\n",
+    "    if thk == '-':\n",
+    "        thk = np.nan\n",
+    "    else:\n",
+    "        thk = float(thk)\n",
+    "    return fm_name.strip(), float(mdrt.strip()), float(tvdss.strip()), thk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(\n",
+    "    [line_to_items(line) for line in fmlog.splitlines()[3:]], \n",
+    "    columns=[\"formation_name\", \"mdrt\", \"tvdss\", \"thickness\"]\n",
+    ")\n",
+    "df.to_csv(Path(\"..\") / \"kronos_1_strat.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Data/kronos_1_strat.csv
+++ b/Data/kronos_1_strat.csv
@@ -1,0 +1,15 @@
+,formation_name,mdrt,tvdss,thickness
+0,Sea Bed,533.8,-512.0,
+1,Barracouta Formation,533.8,-512.0,434.0
+2,Oliver Limestone Formation,968.0,-946.0,1475.0
+3,Prion Limestone Formation,2443.0,-2421.0,415.0
+4,Grebe Limestone Formation,2858.0,-2835.4,817.0
+5,Heywood Limestone Member,2858.0,-2835.4,602.0
+6,Baudin Marl Member,3460.0,-3437.2,215.0
+7,Johnson Formation,3675.0,-3652.3,244.0
+8,Woolaston Gibson Fenalon Prudhoe Fm,3919.0,-3897.0,145.0
+9,Jamieson Formation,4064.0,-4042.0,513.0
+10,Montara Formation,4577.0,-4555.2,8.0
+11,Plover Formation (Top Volcanics),4585.0,-4562.0,191.0
+12,Plover Formation (Top Reservoir),4776.0,-4753.3,299.0
+13,Nome Formation,5075.0,-5050.9,275.8


### PR DESCRIPTION
Included is a jupyter notebook in the `Data/data-notebooks` folder for reading the formation log in the WCR PDFs into a CSV file in the `Data` folder.